### PR TITLE
Replace O(N) per-player item scan with direct table lookup in tooltip hook

### DIFF
--- a/functions/SetGameTooltipPrice.lua
+++ b/functions/SetGameTooltipPrice.lua
@@ -127,22 +127,18 @@ function GreyHandling.functions.ToolTipHook(tooltip)
             end
         end
         for playerName, items in pairs(GreyHandling.data.items) do
-            if not playerName then
-                break
-            end
-            for items_id, itemInformation  in pairs(items) do
-                if items_id == link then
-                    if itemInformation.confidence == 1 then
-                        GameTooltip:AddLine(
-                            format("(G) %s: %s/%s", playerName, itemInformation.number,
-                                itemInformation.itemStackCount), 0.5, 1, 0.5
-                        )
-                    else
-                        GameTooltip:AddLine(
-                            format("(?) %s: %s/%s", playerName, itemInformation.number,
-                                itemInformation.itemStackCount), 0.5, 0.5, 1
-                        )
-                    end
+            local itemInformation = items[link]
+            if itemInformation then
+                if itemInformation.confidence == 1 then
+                    GameTooltip:AddLine(
+                        format("(G) %s: %s/%s", playerName, itemInformation.number,
+                            itemInformation.itemStackCount), 0.5, 1, 0.5
+                    )
+                else
+                    GameTooltip:AddLine(
+                        format("(?) %s: %s/%s", playerName, itemInformation.number,
+                            itemInformation.itemStackCount), 0.5, 0.5, 1
+                    )
                 end
             end
         end


### PR DESCRIPTION
The tooltip hook fires on every item mouseover and walked every player's full item table comparing each key to the hovered link. Items are keyed by itemLink, so a single `items[link]` lookup is equivalent and turns each player's contribution from O(items) into O(1).